### PR TITLE
Remove unused imports including deprecated imp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,7 @@
-import glob
-import imp
 import io
 import os
 from os import path
-from setuptools import setup, find_packages, Extension
-import sys
+from setuptools import setup, find_packages
 
 MYDIR = path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
The imp module is deprecated and set for removal in Python 3.12, due for release in October:

* https://docs.python.org/3/library/imp.html
* https://devguide.python.org/versions/

Luckily, imp isn't actually used in setup.py, so we can remove it and some other unused imports.

<img width="509" alt="image" src="https://user-images.githubusercontent.com/1324225/234087147-4d0a4110-4da4-41fe-b3a5-02927ca4ad7f.png">
